### PR TITLE
Improve Javadoc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,5 +140,8 @@ The project has no automated tests, but it can be compiled with `mvn package`. T
 - Keep this AGENTS.md file in sync with repository changes.
 - Only update README.md if the information becomes outdated.
 
+### Recent Changes
+* Added missing Javadoc comments across the code base to address build warnings.
+
 Wichtig: Aktualisiere AGENTS.md nach jedem Task.
 Wichtig: Aktualisiere die README.md nach jedem Task nur wenn die Informationen darin veraltet sind

--- a/src/main/java/de/entwicklertraining/openai4j/OpenAIResponse.java
+++ b/src/main/java/de/entwicklertraining/openai4j/OpenAIResponse.java
@@ -27,6 +27,8 @@ public abstract class OpenAIResponse<T extends OpenAIRequest<?>> extends ApiResp
 
     /**
      * Returns the raw JSON object of the response.
+     *
+     * @return parsed JSON payload
      */
     public JSONObject getJson() {
         return json;

--- a/src/main/java/de/entwicklertraining/openai4j/OpenAIToolCallContext.java
+++ b/src/main/java/de/entwicklertraining/openai4j/OpenAIToolCallContext.java
@@ -6,11 +6,9 @@ import org.json.JSONObject;
  * Context object passed to a {@link OpenAIToolsCallback} when a tool is invoked by
  * the Chat Completions API.  It exposes the JSON arguments supplied by the
  * model so that the callback can process them.
+ *
+ * @param arguments Raw JSON arguments of the tool call. The structure corresponds
+ *                  to the schema defined in
+ *                  {@link OpenAIToolDefinition.Builder#parameter(String, OpenAIJsonSchema, boolean)}.
  */
-public record OpenAIToolCallContext(
-        /**
-         * Raw JSON arguments of the tool call as provided by the model.
-         * The structure corresponds to the schema defined in
-         * {@link OpenAIToolDefinition.Builder#parameter(String, OpenAIJsonSchema, boolean)}.
-         */
-        JSONObject arguments) { }
+public record OpenAIToolCallContext(JSONObject arguments) { }

--- a/src/main/java/de/entwicklertraining/openai4j/chat/completion/OpenAIChatCompletionAudioParams.java
+++ b/src/main/java/de/entwicklertraining/openai4j/chat/completion/OpenAIChatCompletionAudioParams.java
@@ -32,10 +32,20 @@ public class OpenAIChatCompletionAudioParams {
         this.format = format;
     }
 
+    /**
+     * Returns the voice used for speech synthesis.
+     *
+     * @return the selected voice
+     */
     public SpeechVoice getVoice() {
         return voice;
     }
 
+    /**
+     * Returns the audio format for the generated speech.
+     *
+     * @return the response format
+     */
     public SpeechResponseFormat getFormat() {
         return format;
     }

--- a/src/main/java/de/entwicklertraining/openai4j/chat/completion/OpenAIChatCompletionRequest.java
+++ b/src/main/java/de/entwicklertraining/openai4j/chat/completion/OpenAIChatCompletionRequest.java
@@ -74,6 +74,9 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
         }
     }
 
+    /**
+     * Level of detail to use when the request includes image inputs.
+     */
     public enum ImageDetail {
         LOW("low"),
         HIGH("high"),
@@ -93,6 +96,9 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
         }
     }
 
+    /**
+     * Additional options applicable when streaming responses.
+     */
     public enum StreamOption {
         INCLUDE_USAGE("include_usage");
 
@@ -208,18 +214,38 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
         this.webSearchOptions = webSearchOptions; // Added assignment
     }
 
+    /**
+     * Returns the model identifier for the request.
+     *
+     * @return the model name
+     */
     public String model() {
         return model;
     }
 
+    /**
+     * Returns the chat messages that make up the conversation history.
+     *
+     * @return immutable list of message JSON objects
+     */
     public List<JSONObject> messages() {
         return messages;
     }
 
+    /**
+     * Returns the tools available to the model.
+     *
+     * @return list of tool definitions
+     */
     public List<OpenAIToolDefinition> tools() {
         return tools;
     }
 
+    /**
+     * Desired format of the API response.
+     *
+     * @return response format object or {@code null}
+     */
     public OpenAIResponseFormat responseFormat() {
         return responseFormat;
     }
@@ -230,6 +256,11 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      *  - REQUIRED => must call a tool
      *  - NONE => no tool calls
      */
+    /**
+     * Strategy used for tool calling (auto, required, none).
+     *
+     * @return the configured tool choice or {@code null}
+     */
     public ToolChoice toolChoiceEnum() {
         return toolChoiceEnum;
     }
@@ -237,10 +268,20 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
     /**
      * If non-null, indicates we are forcing the model to call exactly this specific tool.
      */
+    /**
+     * Tool that the model is forced to invoke, if any.
+     *
+     * @return the forced tool definition or {@code null}
+     */
     public OpenAIToolDefinition forcedTool() {
         return forcedToolChoice;
     }
 
+    /**
+     * Whether multiple tool calls may be returned in a single response.
+     *
+     * @return {@code Boolean} flag or {@code null} for server default
+     */
     public Boolean parallelToolCalls() {
         return parallelToolCalls;
     }
@@ -248,14 +289,24 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
     /**
      * Returns the parameters for audio output, if specified.
      */
-    public OpenAIChatCompletionAudioParams audioParams() { // Added getter
+    /**
+     * Parameters controlling audio output, if requested.
+     *
+     * @return audio parameter object or {@code null}
+     */
+    public OpenAIChatCompletionAudioParams audioParams() {
         return audioParams;
     }
 
     /**
      * Returns the frequency penalty value, if specified.
      */
-    public Double frequencyPenalty() { // Added getter
+    /**
+     * Frequency penalty to apply when generating text.
+     *
+     * @return frequency penalty value or {@code null}
+     */
+    public Double frequencyPenalty() {
         return frequencyPenalty;
     }
 
@@ -263,7 +314,12 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      * Returns the logit bias map, if specified.
      * Keys are token IDs, values are bias adjustments (-100 to 100).
      */
-    public Map<Integer, Integer> logitBias() { // Added getter
+    /**
+     * Map of token IDs to bias adjustments applied during sampling.
+     *
+     * @return unmodifiable bias map or {@code null}
+     */
+    public Map<Integer, Integer> logitBias() {
         // Return an unmodifiable view to prevent external modification
         return (logitBias != null) ? Collections.unmodifiableMap(logitBias) : null;
     }
@@ -271,10 +327,20 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
     /**
      * Returns whether log probabilities should be returned, if specified.
      */
-    public Boolean logprobs() { // Added getter
+    /**
+     * Whether log probabilities should be included in the response.
+     *
+     * @return {@code Boolean} flag or {@code null}
+     */
+    public Boolean logprobs() {
         return logprobs;
     }
 
+    /**
+     * Nucleus sampling parameter controlling diversity.
+     *
+     * @return top_p value or {@code null}
+     */
     public Double topP() {
         return topP;
     }
@@ -285,7 +351,12 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      * This parameter replaces the deprecated {@code max_tokens} parameter.
      * See <a href="https://platform.openai.com/docs/guides/reasoning">OpenAI Reasoning Tokens Documentation</a> for details.
      */
-    public Integer maxCompletionTokens() { // Added getter
+    /**
+     * Upper bound for the number of tokens that can be generated for a completion.
+     *
+     * @return maximum completion tokens or {@code null}
+     */
+    public Integer maxCompletionTokens() {
         return maxCompletionTokens;
     }
 
@@ -293,7 +364,12 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      * Returns the metadata map, if specified.
      * Keys have max length 64, values max length 512. Max 16 pairs.
      */
-    public Map<String, String> metadata() { // Added getter
+    /**
+     * Optional metadata attached to the request.
+     *
+     * @return unmodifiable metadata map or {@code null}
+     */
+    public Map<String, String> metadata() {
         // Return an unmodifiable view
         return (metadata != null) ? Collections.unmodifiableMap(metadata) : null;
     }
@@ -302,7 +378,12 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      * Returns the set of requested output modalities.
      * Defaults to a set containing only {@link OpenAIOutputModality#TEXT}.
      */
-    public Set<OpenAIOutputModality> modalities() { // Added getter
+    /**
+     * Output modalities requested from the API.
+     *
+     * @return set of modalities
+     */
+    public Set<OpenAIOutputModality> modalities() {
         // Return an unmodifiable view
         return Collections.unmodifiableSet(modalities);
     }
@@ -310,14 +391,24 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
     /**
      * Returns the number of chat completion choices to generate, if specified.
      */
-    public Integer n() { // Added getter
+    /**
+     * Number of chat completion choices to generate.
+     *
+     * @return number of choices or {@code null}
+     */
+    public Integer n() {
         return n;
     }
 
     /**
      * Returns the prediction parameters, if specified.
      */
-    public OpenAIChatCompletionPredictionParams predictionParams() { // Added getter
+    /**
+     * Prediction parameters optionally provided to speed up responses.
+     *
+     * @return prediction parameters or {@code null}
+     */
+    public OpenAIChatCompletionPredictionParams predictionParams() {
         return predictionParams;
     }
 
@@ -327,7 +418,12 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      * whether they appear in the text so far, increasing the model's likelihood
      * to talk about new topics.
      */
-    public Double presencePenalty() { // Added getter
+    /**
+     * Presence penalty influencing topic diversity.
+     *
+     * @return presence penalty value or {@code null}
+     */
+    public Double presencePenalty() {
         return presencePenalty;
     }
 
@@ -335,54 +431,103 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
      * Returns the reasoning effort setting, if specified.
      * Applicable only for o-series models.
      */
-    public OpenAIReasoningEffort reasoningEffort() { // Added getter
+    /**
+     * Effort level for reasoning in o-series models.
+     *
+     * @return reasoning effort or {@code null}
+     */
+    public OpenAIReasoningEffort reasoningEffort() {
         return reasoningEffort;
     }
 
     /**
      * Returns the seed value for deterministic sampling, if specified.
      */
+    /**
+     * Seed for deterministic sampling.
+     *
+     * @return seed value or {@code null}
+     */
     public Integer seed() {
         return seed;
     }
 
+    /**
+     * Identifier representing the end user of the application.
+     *
+     * @return user identifier or {@code null}
+     */
     public String user() {
         return user;
     }
 
+    /**
+     * Whether the response should be streamed.
+     *
+     * @return {@code true} if streaming is enabled
+     */
     public boolean stream() {
         return stream;
     }
 
+    /**
+     * Sampling temperature used for the request.
+     *
+     * @return temperature value or {@code null}
+     */
     public Double temperature() {
         return temperature;
     }
 
+    /**
+     * Additional stream options requested from the API.
+     *
+     * @return set of options or {@code null}
+     */
     public Set<StreamOption> streamOptions() {
         return streamOptions != null ? Collections.unmodifiableSet(streamOptions) : null;
     }
 
+    /**
+     * Service tier used for processing the request.
+     *
+     * @return the service tier or {@code null}
+     */
     public OpenAIServiceTier serviceTier() {
         return serviceTier;
     }
 
+    /**
+     * Stop sequences that will terminate generation when encountered.
+     *
+     * @return list of stop sequences or {@code null}
+     */
     public List<String> stopSequences() {
         return stopSequences;
     }
 
+    /**
+     * Number of log probabilities to return for each generated token.
+     *
+     * @return count of top log probabilities or {@code null}
+     */
     public Integer topLogprobs() {
         return topLogprobs;
     }
 
     /**
-     * Returns the web search options, if specified.
+     * Options controlling the integrated web search capability.
+     *
+     * @return web search options or {@code null}
      */
-    public OpenAIWebSearchOptions webSearchOptions() { // Added getter
+    public OpenAIWebSearchOptions webSearchOptions() {
         return webSearchOptions;
     }
 
     /**
      * Builds the JSON body for this request.
+     *
+     * @return request body as a JSON object
      */
     public JSONObject toJson() {
         JSONObject body = new JSONObject();
@@ -589,6 +734,9 @@ public final class OpenAIChatCompletionRequest extends OpenAIRequest<OpenAIChatC
         return new Builder(client);
     }
 
+    /**
+     * Fluent builder for {@link OpenAIChatCompletionRequest} instances.
+     */
     public static final class Builder extends ApiRequestBuilderBase<Builder, OpenAIChatCompletionRequest> {
         private final OpenAIClient client;
         private String model;

--- a/src/main/java/de/entwicklertraining/openai4j/embeddings/EmbeddingEncodingFormat.java
+++ b/src/main/java/de/entwicklertraining/openai4j/embeddings/EmbeddingEncodingFormat.java
@@ -8,7 +8,9 @@ package de.entwicklertraining.openai4j.embeddings;
  * </ul>
  */
 public enum EmbeddingEncodingFormat {
+    /** floating point vector */
     FLOAT("float"),
+    /** base64 encoded vector */
     BASE64("base64");
 
     private final String value;
@@ -19,6 +21,8 @@ public enum EmbeddingEncodingFormat {
 
     /**
      * Returns the string literal used in API requests.
+     *
+     * @return API literal for this encoding
      */
     public String value() {
         return value;

--- a/src/main/java/de/entwicklertraining/openai4j/embeddings/EmbeddingModel.java
+++ b/src/main/java/de/entwicklertraining/openai4j/embeddings/EmbeddingModel.java
@@ -6,8 +6,11 @@ package de.entwicklertraining.openai4j.embeddings;
  */
 public enum EmbeddingModel {
 
+    /** Newest small embedding model */
     TEXT_EMBEDDING_3_SMALL("text-embedding-3-small"),
+    /** Larger variant with higher quality */
     TEXT_EMBEDDING_3_LARGE("text-embedding-3-large"),
+    /** Legacy ada model */
     TEXT_EMBEDDING_ADA_002("text-embedding-ada-002");
 
     private final String value;
@@ -18,6 +21,8 @@ public enum EmbeddingModel {
 
     /**
      * Returns the literal model identifier used by the API.
+     *
+     * @return API model name
      */
     public String value() {
         return value;

--- a/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE2Request.java
+++ b/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE2Request.java
@@ -79,18 +79,38 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
         return new DallE2Response(responseBody, this);
     }
 
+    /**
+     * Returns the textual prompt used to generate the images.
+     *
+     * @return the prompt text
+     */
     public String prompt() {
         return prompt;
     }
 
+    /**
+     * Requested size of the generated image.
+     *
+     * @return the image size
+     */
     public ImageSize size() {
         return size;
     }
 
+    /**
+     * Format of the response returned by the API.
+     *
+     * @return the response format
+     */
     public ResponseFormat responseFormat() {
         return responseFormat;
     }
 
+    /**
+     * Number of images requested from the API.
+     *
+     * @return the amount of images to generate
+     */
     public int n() {
         return n;
     }
@@ -130,6 +150,9 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
 
         /**
          * Sets the textual prompt to generate from.
+         *
+         * @param prompt the image description
+         * @return this builder instance
          */
         public Builder prompt(String prompt) {
             this.prompt = prompt;
@@ -138,6 +161,9 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
 
         /**
          * Specifies the desired image size.
+         *
+         * @param size the requested size
+         * @return this builder instance
          */
         public Builder size(ImageSize size) {
             this.size = size;
@@ -146,6 +172,9 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
 
         /**
          * Sets the response format.
+         *
+         * @param rf the desired response format
+         * @return this builder instance
          */
         public Builder responseFormat(ResponseFormat rf) {
             this.responseFormat = rf;
@@ -154,6 +183,9 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
 
         /**
          * Number of images to generate (1–10).
+         *
+         * @param n number of images
+         * @return this builder instance
          */
         public Builder n(int n) {
             this.n = n;
@@ -162,6 +194,8 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
 
         /**
          * Builds the request using the configured parameters.
+         *
+         * @return immutable request instance
          */
         public DallE2Request build() {
             return new DallE2Request(this, prompt, size, responseFormat, n);
@@ -188,8 +222,11 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
      * DALL·E 2 valid sizes.
      */
     public enum ImageSize {
+        /** 256 by 256 pixels */
         SIZE_256x256("256x256"),
+        /** 512 by 512 pixels */
         SIZE_512x512("512x512"),
+        /** 1024 by 1024 pixels */
         SIZE_1024x1024("1024x1024");
 
         private final String value;
@@ -198,6 +235,8 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
         }
         /**
          * Returns the literal size used by the API.
+         *
+         * @return API string for this size
          */
         public String value() {
             return value;
@@ -208,7 +247,9 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
      * Supported response formats for DALL·E 2 requests.
      */
     public enum ResponseFormat {
+        /** URLs to the generated images */
         URL("url"),
+        /** Base64-encoded image data */
         B64_JSON("b64_json");
 
         private final String value;
@@ -217,6 +258,8 @@ public final class DallE2Request extends OpenAIRequest<DallE2Response> {
         }
         /**
          * API string for this response format.
+         *
+         * @return literal used in requests
          */
         public String value() {
             return value;

--- a/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE2Response.java
+++ b/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE2Response.java
@@ -15,6 +15,12 @@ public final class DallE2Response extends OpenAIResponse<DallE2Request> {
 
     private final List<String> images = new ArrayList<>();
 
+    /**
+     * Parses the raw response body returned by the API.
+     *
+     * @param rawBody  JSON string returned by the API
+     * @param request  originating request instance
+     */
     public DallE2Response(String rawBody, DallE2Request request) {
         super(new JSONObject(rawBody), request);
         parseImages();
@@ -37,8 +43,11 @@ public final class DallE2Response extends OpenAIResponse<DallE2Request> {
 
     /**
      * Returns the list of generated images.
-     * If the request used ResponseFormat.URL, these are URLs.
-     * If the request used ResponseFormat.B64_JSON, these are base64-encoded strings.
+     * If the request used {@link DallE2Request.ResponseFormat#URL}, these are URLs.
+     * If the request used {@link DallE2Request.ResponseFormat#B64_JSON}, these are
+     * base64-encoded strings.
+     *
+     * @return immutable list of image results
      */
     public List<String> images() {
         return Collections.unmodifiableList(images);

--- a/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE3Request.java
+++ b/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE3Request.java
@@ -99,7 +99,11 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
     }
 
     /**
-     * Final prompt that will be used, considering noMoreDetail if applicable.
+     * Final prompt that will be sent to the API.
+     * If {@code noMoreDetail} is {@code true}, a note requesting no additional
+     * detail is prepended.
+     *
+     * @return the prompt actually used for the request
      */
     public String effectivePrompt() {
         if (noMoreDetail) {
@@ -119,30 +123,65 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
         return new Builder(client);
     }
 
+    /**
+     * Original prompt text supplied by the user.
+     *
+     * @return the prompt
+     */
     public String prompt() {
         return prompt;
     }
 
+    /**
+     * Requested image size.
+     *
+     * @return the image size
+     */
     public ImageSize size() {
         return size;
     }
 
+    /**
+     * Response format specifying whether URLs or base64 data are returned.
+     *
+     * @return the response format
+     */
     public ResponseFormat responseFormat() {
         return responseFormat;
     }
 
+    /**
+     * Number of images requested from the API.
+     *
+     * @return the number of images
+     */
     public int n() {
         return n;
     }
 
+    /**
+     * Optional quality setting for the generated image.
+     *
+     * @return the image quality or {@code null} if default
+     */
     public ImageQuality quality() {
         return quality;
     }
 
+    /**
+     * Optional style hint used for image generation.
+     *
+     * @return the image style or {@code null} if not set
+     */
     public ImageStyle style() {
         return style;
     }
 
+    /**
+     * Indicates whether a "no more detail" note is prepended to the prompt.
+     *
+     * @return {@code true} if no additional detail should be added
+     */
     public boolean noMoreDetail() {
         return noMoreDetail;
     }
@@ -175,6 +214,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Sets the prompt describing the desired image.
+         *
+         * @param prompt the image description
+         * @return this builder instance
          */
         public Builder prompt(String prompt) {
             this.prompt = prompt;
@@ -183,6 +225,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Sets the image size to request.
+         *
+         * @param size the desired image size
+         * @return this builder instance
          */
         public Builder size(ImageSize size) {
             this.size = size;
@@ -191,6 +236,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Sets the desired response format.
+         *
+         * @param rf the response format
+         * @return this builder instance
          */
         public Builder responseFormat(ResponseFormat rf) {
             this.responseFormat = rf;
@@ -199,6 +247,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Number of images to generate. The API typically only allows {@code 1}.
+         *
+         * @param n number of images
+         * @return this builder instance
          */
         public Builder n(int n) {
             this.n = n;
@@ -207,6 +258,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Optional image quality setting.
+         *
+         * @param quality desired image quality
+         * @return this builder instance
          */
         public Builder quality(ImageQuality quality) {
             this.quality = quality;
@@ -215,6 +269,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Optional style hint for the image.
+         *
+         * @param style desired image style
+         * @return this builder instance
          */
         public Builder style(ImageStyle style) {
             this.style = style;
@@ -223,6 +280,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * If true, prepends a note to the prompt requesting no additional detail.
+         *
+         * @param val whether to add the no-more-detail flag
+         * @return this builder instance
          */
         public Builder noMoreDetail(boolean val) {
             this.noMoreDetail = val;
@@ -231,6 +291,8 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
 
         /**
          * Builds the request using the configured parameters.
+         *
+         * @return immutable request instance
          */
         public DallE3Request build() {
             return new DallE3Request(
@@ -268,8 +330,11 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
      * Supported image sizes for DALL·E 3.
      */
     public enum ImageSize {
+        /** 1024x1024 pixels */
         SIZE_1024x1024("1024x1024"),
+        /** 1024x1792 pixels */
         SIZE_1024x1792("1024x1792"),
+        /** 1792x1024 pixels */
         SIZE_1792x1024("1792x1024");
 
         private final String value;
@@ -278,6 +343,8 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
         }
         /**
          * Returns the literal size value used by the API.
+         *
+         * @return API string for this size
          */
         public String value() {
             return value;
@@ -288,7 +355,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
      * Quality options for generated images.
      */
     public enum ImageQuality {
+        /** Standard quality */
         STANDARD("standard"),
+        /** High definition quality */
         HD("hd");
 
         private final String value;
@@ -297,6 +366,8 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
         }
         /**
          * API literal for image quality.
+         *
+         * @return string used by the API
          */
         public String value() {
             return value;
@@ -307,7 +378,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
      * Style options controlling the visual appearance of the result.
      */
     public enum ImageStyle {
+        /** Vivid, saturated colors */
         VIVID("vivid"),
+        /** Natural, subdued colors */
         NATURAL("natural");
 
         private final String value;
@@ -316,6 +389,8 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
         }
         /**
          * API literal for image style.
+         *
+         * @return string used by the API
          */
         public String value() {
             return value;
@@ -326,7 +401,9 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
      * Format of the API response payload.
      */
     public enum ResponseFormat {
+        /** URLs pointing to the images */
         URL("url"),
+        /** Base64-encoded image data */
         B64_JSON("b64_json");
 
         private final String value;
@@ -335,6 +412,8 @@ public final class DallE3Request extends OpenAIRequest<DallE3Response> {
         }
         /**
          * String used to request the corresponding response format.
+         *
+         * @return API literal for this format
          */
         public String value() {
             return value;

--- a/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE3Response.java
+++ b/src/main/java/de/entwicklertraining/openai4j/images/generations/DallE3Response.java
@@ -15,6 +15,12 @@ public final class DallE3Response extends OpenAIResponse<DallE3Request> {
 
     private final List<String> images = new ArrayList<>();
 
+    /**
+     * Parses the raw response returned by the API.
+     *
+     * @param rawBody JSON payload from the API
+     * @param request originating request instance
+     */
     public DallE3Response(String rawBody, DallE3Request request) {
         super(new JSONObject(rawBody), request);
         parseImages();
@@ -35,6 +41,12 @@ public final class DallE3Response extends OpenAIResponse<DallE3Request> {
         }
     }
 
+    /**
+     * Returns the generated images as URLs or base64 strings depending on the
+     * request's {@link DallE3Request.ResponseFormat}.
+     *
+     * @return immutable list of image results
+     */
     public List<String> images() {
         return Collections.unmodifiableList(images);
     }


### PR DESCRIPTION
## Summary
- add parameter Javadoc for `OpenAIToolCallContext`
- document getters and builder methods for DALL·E requests
- clarify response classes and enums
- expand chat completion documentation
- note update in AGENTS log

## Testing
- `mvn package` *(fails: Could not resolve central-publishing-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6840a0b6b0d883278b5b28a2c60fdd99