### PR TITLE
Improve README with new examples

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,6 +144,7 @@ The project has no automated tests, but it can be compiled with `mvn package`. T
 ### Recent Changes
 * Added missing Javadoc comments across the code base to address build warnings.
 * Added an important notice at the beginning of README about supported OpenAI features.
+* Expanded README with new examples including ApiClientSettings usage and embeddings.
 
 Wichtig: Aktualisiere AGENTS.md nach jedem Task.
 Wichtig: Aktualisiere die README.md nach jedem Task nur wenn die Informationen darin veraltet sind

--- a/README.md
+++ b/README.md
@@ -78,8 +78,32 @@ List<String> images = response.images();
 ```
 【F:examples/src/main/java/de/entwicklertraining/openai4j/examples/DallE3Example.java†L26-L43】
 
-See the `examples` module for more demonstrations (embeddings, speech, translation, web search
-and vision).
+### Configuring the Client
+
+`OpenAIClient` accepts an `ApiClientSettings` object for fine‑grained control over retries and timeouts. The API key can be configured directly and a hook can inspect each request before it is sent:
+
+```java
+ApiClientSettings settings = ApiClientSettings.builder()
+        .setBearerAuthenticationKey(System.getenv("OPENAI_API_KEY"))
+        .beforeSend(req -> System.out.println("Sending " + req.getHttpMethod() + " " + req.getRelativeUrl()))
+        .build();
+
+OpenAIClient client = new OpenAIClient(settings);
+```
+
+### Embeddings Example
+
+```java
+OpenAIClient client = new OpenAIClient();
+OpenAIEmbeddingsResponse emb = client.embeddings()
+        .model(EmbeddingModel.TEXT_EMBEDDING_3_SMALL)
+        .addInput("OpenAI provides powerful language models.")
+        .addInput("Large language models are offered by OpenAI.")
+        .execute();
+List<double[]> vecs = emb.embeddingsFloat();
+```
+
+See the `examples` module for more demonstrations (speech, translation, web search and vision).
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- show how to configure `ApiClientSettings` in the README
- provide an embeddings example
- record recent documentation changes in `AGENTS.md`

## Testing
- `mvn -q package` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_6841fb7e05b083279ea7ae0e855f94db