### PR TITLE
Add audio-service docs and example note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ The project has no automated tests, but it can be compiled with `mvn package`. T
 * Added missing Javadoc comments across the code base to address build warnings.
 * Added an important notice at the beginning of README about supported OpenAI features.
 * Expanded README with new examples including ApiClientSettings usage and embeddings.
+* Documented the optional audio-service module and updated the README with an Optional Modules section.
 
 Wichtig: Aktualisiere AGENTS.md nach jedem Task.
 Wichtig: Aktualisiere die README.md nach jedem Task nur wenn die Informationen darin veraltet sind

--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ Add the dependency from Maven Central:
 </dependency>
 ```
 
+## Optional Modules
+
+This repository contains additional modules that build on top of the core
+library. They are not required but provide convenient helpers for certain
+tasks.
+
+* **`openai4j-audio-service`** – automatically chunks large audio files and
+  merges multiple Whisper transcriptions. See the
+  [OpenAITranscribeAudioServiceExample.java](openai4j-examples/src/main/java/de/entwicklertraining/openai4j/examples/OpenAITranscribeAudioServiceExample.java)
+  for a usage example.
+
 ## Basic Usage
 
 Instantiate a `OpenAIClient` and use the builders exposed by its fluent API. The

--- a/openai4j-audio-service/README.md
+++ b/openai4j-audio-service/README.md
@@ -1,0 +1,21 @@
+# OpenAI4J - Audio Service
+
+This optional module extends the core `openai4j` library with a helper
+service for audio transcription. Large or unsupported audio files are
+split into smaller chunks, transcribed with the Whisper model and then
+recombined. The service can return plain text, SRT/VTT subtitles or a
+verbose JSON structure with word and segment timestamps.
+
+Add it alongside the main dependency:
+
+```xml
+<dependency>
+    <groupId>de.entwicklertraining</groupId>
+    <artifactId>openai4j-audio-service</artifactId>
+    <version>1.0.0</version>
+</dependency>
+```
+
+See the example in
+[`../openai4j-examples/src/main/java/de/entwicklertraining/openai4j/examples/OpenAITranscribeAudioServiceExample.java`](../openai4j-examples/src/main/java/de/entwicklertraining/openai4j/examples/OpenAITranscribeAudioServiceExample.java)
+for how to use the service.

--- a/openai4j-examples/src/main/java/de/entwicklertraining/openai4j/examples/OpenAITranscribeAudioServiceExample.java
+++ b/openai4j-examples/src/main/java/de/entwicklertraining/openai4j/examples/OpenAITranscribeAudioServiceExample.java
@@ -13,6 +13,11 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
 
+/**
+ * Demonstrates the {@code OpenAITranscribeAudioService}.
+ * To run this example you need to include the optional
+ * {@code openai4j-audio-service} dependency in your project.
+ */
 public class OpenAITranscribeAudioServiceExample {
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION
## Summary
- add README for the optional audio-service module
- document the optional module in the main README
- hint about the dependency in the transcription example
- update AGENTS

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q package` *(fails: Unresolveable build extension)*

------
https://chatgpt.com/codex/tasks/task_e_6843e63d2d70832796b4edf81d40bfc8