### PR TITLE
Fix javadoc links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -145,6 +145,7 @@ The project has no automated tests, but it can be compiled with `mvn package`. T
 * Added missing Javadoc comments across the code base to address build warnings.
 * Added an important notice at the beginning of README about supported OpenAI features.
 * Expanded README with new examples including ApiClientSettings usage and embeddings.
+* Fixed broken Javadoc links in OpenAITranscribeAudioService.
 
 Wichtig: Aktualisiere AGENTS.md nach jedem Task.
 Wichtig: Aktualisiere die README.md nach jedem Task nur wenn die Informationen darin veraltet sind

--- a/openai4j-audio-service/src/main/java/de/entwicklertraining/openai4j/audio/service/OpenAITranscribeAudioService.java
+++ b/openai4j-audio-service/src/main/java/de/entwicklertraining/openai4j/audio/service/OpenAITranscribeAudioService.java
@@ -103,7 +103,7 @@ public final class OpenAITranscribeAudioService {
 
     /**
      * Transcribe audio to a {@link VerboseTranscription}, merging chunk results
-     * via {@link OpenAIVerboseTranscriptionService(VerboseTranscription...)}.
+     * via {@link OpenAIVerboseTranscriptionService#combine(VerboseTranscription...)}.
      */
     public VerboseTranscription transcribeAudioToVerboseTranscription(Path filePath) {
         return transcribeAudioToVerboseTranscription(filePath, new TranscriptionSettings());
@@ -111,7 +111,7 @@ public final class OpenAITranscribeAudioService {
 
     /**
      * Transcribe audio to a {@link VerboseTranscription}, merging chunk results
-     * via {@link OpenAIVerboseTranscriptionService(VerboseTranscription...)}.
+     * via {@link OpenAIVerboseTranscriptionService#combine(VerboseTranscription...)}.
      */
     public VerboseTranscription transcribeAudioToVerboseTranscription(Path filePath, TranscriptionSettings settings) {
         List<VerboseTranscription> transcriptions =


### PR DESCRIPTION
## Summary
- fix malformed `OpenAIVerboseTranscriptionService` links
- document change in AGENTS

## Testing
- `mvn -q package` *(fails: central-publishing-maven-plugin could not be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_6843e728931483279f2a8feef916372f