### PR TITLE
Update docs for audio service

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ and convenient way to access OpenAI services from modern Java (JDK&nbsp;21+).
 * Chat Completions including tool calling, structured outputs and vision inputs
 * Image generation with GPT-4o's `image-1`, DALL·E&nbsp;2 and DALL·E&nbsp;3
 * Embeddings with helper for cosine similarity
-* Speech synthesis (TTS), audio transcription and translation
+* Speech synthesis (TTS), audio transcription and translation, plus a service to chunk and merge audio files
 * Token counting utilities via `jtokkit`
 * Fluent builder APIs for all requests
 * Examples demonstrating each feature
@@ -25,7 +25,7 @@ Add the dependency from Maven Central:
 <dependency>
     <groupId>de.entwicklertraining</groupId>
     <artifactId>openai4j</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -91,6 +91,7 @@ The library follows a clear structure:
   `OpenAIToolsCallback` and `OpenAIToolCallContext`.
 * **Structured outputs** – use `OpenAIJsonSchema` and `OpenAIResponseFormat`.
 * **Token utilities** – `OpenAITokenService` counts tokens via `jtokkit`.
+* **Audio services** – module `openai4j-audio-service` provides `OpenAITranscribeAudioService` for chunking files and merging SRT/VTT outputs.
 
 The examples directory mirrors these packages and can be used as a quick start.
 
@@ -125,15 +126,16 @@ OpenAI4J is distributed under the MIT License as defined in the project `pom.xml
 
 ## Additional Details
 
-This Maven-based project targets JDK 21 and provides a fluent Java wrapper around the OpenAI REST API. The main module `openai4j` exposes builders for chat completions, image generation, embeddings and audio endpoints. Example usages are located in `examples/src/main/java/de/entwicklertraining/openai4j/examples`.
+This Maven-based project targets JDK 21 and provides a fluent Java wrapper around the OpenAI REST API. The main module `openai4j` exposes builders for chat completions, image generation, embeddings and audio endpoints. The `openai4j-audio-service` submodule builds on top and offers `OpenAITranscribeAudioService` to handle chunking and merging of audio files. It also provides `AudioChunker`, `SrtService`, `VttService` and `OpenAIVerboseTranscriptionService` for working with chunked audio and subtitle formats. Example usages are located in `examples/src/main/java/de/entwicklertraining/openai4j/examples`.
 
 Important packages include:
 - `chat.completion` – classes like `OpenAIChatCompletionRequest` and `OpenAIChatCompletionResponse` implement the Chat Completions API.
 - `images.generations` – includes request builders such as `DallE3Request` for image generation.
 - `audio.*` – speech, transcription and translation requests.
 - `embeddings` – utilities for embeddings and cosine similarity.
+- `audio.service` – utilities in the `openai4j-audio-service` module for chunking audio and creating SRT/VTT outputs.
 
-The project has no automated tests, but it can be compiled with `mvn package`. The examples module depends on `openai4j` and demonstrates features such as tool calling, DALL·E 3 image generation and speech synthesis.
+The project has no automated tests, but it can be compiled with `mvn package`. The examples module depends on `openai4j` and `openai4j-audio-service` and demonstrates features such as tool calling, DALL·E 3 image generation and speech synthesis.
 
 
 ## Maintenance
@@ -145,6 +147,8 @@ The project has no automated tests, but it can be compiled with `mvn package`. T
 * Added missing Javadoc comments across the code base to address build warnings.
 * Added an important notice at the beginning of README about supported OpenAI features.
 * Expanded README with new examples including ApiClientSettings usage and embeddings.
+* Introduced new submodule `openai4j-audio-service` with helpers for chunking audio and creating SRT/VTT files.
+* Bumped project version to 1.1.0.
 
 Wichtig: Aktualisiere AGENTS.md nach jedem Task.
 Wichtig: Aktualisiere die README.md nach jedem Task nur wenn die Informationen darin veraltet sind

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and convenient way to access OpenAI services from Java, being as close to the ra
 * Chat Completions including tool calling, structured outputs and vision inputs
 * Image generation with GPT-4o's `image-1`, DALL·E&nbsp;2 and DALL·E&nbsp;3
 * Embeddings with helper for cosine similarity
-* Speech synthesis (TTS), audio transcription and translation + plus a service that chunks audio input for you
+* Speech synthesis (TTS), audio transcription and translation, plus a service to chunk and merge audio files
 * Token counting utilities via `jtokkit`
 * Fluent builder APIs for all requests
 * Examples demonstrating each feature
@@ -30,7 +30,7 @@ Add the dependency from Maven Central:
 <dependency>
     <groupId>de.entwicklertraining</groupId>
     <artifactId>openai4j</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0</version>
 </dependency>
 ```
 
@@ -119,6 +119,7 @@ The library follows a clear structure:
   `OpenAIToolsCallback` and `OpenAIToolCallContext`.
 * **Structured outputs** – use `OpenAIJsonSchema` and `OpenAIResponseFormat`.
 * **Token utilities** – `OpenAITokenService` counts tokens via `jtokkit`.
+* **Audio services** – submodule `openai4j-audio-service` provides helpers for chunking files and merging transcriptions.
 
 The examples directory mirrors these packages and can be used as a quick start.
 


### PR DESCRIPTION
## Summary
- mention new audio service module in docs
- fix feature bullet wording
- note additional audio helpers in AGENTS

## Testing
- `apt-get update -y`
- `apt-get install -y maven`
- `mvn -q package` *(fails: could not resolve central-publishing-maven-plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6843e6847bf48327b9d66b037f437d59